### PR TITLE
Fix docker-compose volume path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@
 version: "3.5"
 services:
   devops-newsfeed:
-    image: anthonyrussano/devops-newsfeeds
+    image: anthonyrussano/devops-newsfeeds:web
     volumes:
-      - ~/.newsfeed:/root/.newsfeed
+      - ~/.newsboat:/home/worker/.newsboat
     ports:
-      - 8080:7681
+      - "8080:7681"


### PR DESCRIPTION
## Summary
- fix the docker-compose service image tag
- mount the correct `~/.newsboat` directory into the container

## Testing
- `yamllint docker-compose.yml`
- `shellcheck entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_687c7dd573dc8333a79b72e83fa0f9a4