### PR TITLE
Add static website generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.db
 *.lock
+site/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,37 @@
+# DevOps Newsfeeds
 
+This repository stores Newsboat configuration and a large collection of RSS feed URLs.
 
 ## CLI Version
 
-`docker run -it anthonyrussano/devops-newsfeeds:cli -c=/root/.newsboat/cache/cache.db`
+Run Newsboat in a container:
+
+```bash
+docker run -it anthonyrussano/devops-newsfeeds:cli -c=/root/.newsboat/cache/cache.db
+```
 
 ## Web Version
 
-`docker run -p 8080:7681 --rm anthonyrussano/devops-newsfeeds:web`
+Run the ttyd-based web interface:
 
-Each user should connect with a unique cache file name parameter in the url.
+```bash
+docker run -p 8080:7681 --rm anthonyrussano/devops-newsfeeds:web
+```
 
-`http://localhost:8080/?arg=-c=/root/.newsboat/cache/unique_cache_name.db`
+Each user should connect with a unique cache file name parameter in the URL:
 
+```bash
+http://localhost:8080/?arg=-c=/root/.newsboat/cache/unique_cache_name.db
+```
 
+## Static website generator
+
+A small script `generate_static.py` can build a static website containing the latest entries from all feeds listed in `urls`.
+Install dependencies and run:
+
+```bash
+pip install feedparser
+python generate_static.py
+```
+
+The generated HTML files will appear in the `site/` directory.

--- a/generate_static.py
+++ b/generate_static.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate a static website with the latest articles from the feeds listed in the
+newsboat `urls` file.
+"""
+import os
+import re
+import datetime
+from pathlib import Path
+
+import feedparser
+import requests
+
+URLS_FILE = Path("urls")
+OUTPUT_DIR = Path("site")
+MAX_FEEDS = int(os.environ.get("MAX_FEEDS", "0"))  # limit number of feeds when testing
+
+
+def parse_urls(file_path: Path):
+    urls = []
+    for line in file_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("\"") or line.startswith("query:"):
+            continue
+        match = re.match(r"(https?://\S+)", line)
+        if match:
+            urls.append(match.group(1))
+    return urls
+
+
+def sanitize(name: str) -> str:
+    name = re.sub(r"[^a-zA-Z0-9_-]+", "_", name.strip())
+    return name[:50] or "feed"
+
+
+def write_feed_page(feed, dest: Path):
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8") as fh:
+        fh.write("<html><head><meta charset='utf-8'><title>{title}</title></head><body>\n".format(title=feed.feed.get("title", "Feed")))
+        fh.write(f"<h1>{feed.feed.get('title', 'Feed')}</h1>\n")
+        fh.write("<ul>\n")
+        for entry in feed.entries:
+            title = entry.get("title", "(no title)")
+            link = entry.get("link", "#")
+            fh.write(f"  <li><a href='{link}'>{title}</a></li>\n")
+        fh.write("</ul>\n")
+        fh.write("</body></html>\n")
+
+
+def main():
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    urls = parse_urls(URLS_FILE)
+    index_entries = []
+    for url in urls:
+        if MAX_FEEDS and len(index_entries) >= MAX_FEEDS:
+            break
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            feed = feedparser.parse(resp.content)
+        except Exception as exc:
+            print(f"Failed to fetch {url}: {exc}")
+            continue
+        title = feed.feed.get("title", url)
+        slug = sanitize(title)
+        dest = OUTPUT_DIR / f"{slug}.html"
+        write_feed_page(feed, dest)
+        index_entries.append((title, dest.name))
+
+    with (OUTPUT_DIR / "index.html").open("w", encoding="utf-8") as index:
+        index.write("<html><head><meta charset='utf-8'><title>Newsboat Static</title></head><body>\n")
+        index.write(f"<h1>Newsboat Static - {datetime.date.today()}</h1>\n")
+        index.write("<ul>\n")
+        for title, filename in sorted(index_entries):
+            index.write(f"  <li><a href='{filename}'>{title}</a></li>\n")
+        index.write("</ul>\n")
+        index.write("</body></html>\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_static.py` for fetching feeds and building a static site
- ignore the generated `site/` folder
- document the static site generator in the README

## Testing
- `MAX_FEEDS=1 python3 generate_static.py`


------
https://chatgpt.com/codex/tasks/task_e_687c81abf29c83339b8ba09427ff3098